### PR TITLE
Add minimal simulators for new automata

### DIFF
--- a/automata/frontend/src/App.js
+++ b/automata/frontend/src/App.js
@@ -1,12 +1,30 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './App.css';
 import Layout from './components/Layout';
 import DFASimulator from './components/DFA_components/DFASimulator';
+import PDASimulator from './components/PDA_components/PDASimulator';
+import CFGSimulator from './components/CFG_components/CFGSimulator';
+import TMSimulator from './components/TM_components/TMSimulator';
 
 function App() {
+  const [automata, setAutomata] = useState('DFA');
+
+  const renderSim = () => {
+    switch (automata) {
+      case 'PDA':
+        return <PDASimulator />;
+      case 'TM':
+        return <TMSimulator />;
+      case 'CFG':
+        return <CFGSimulator />;
+      default:
+        return <DFASimulator />;
+    }
+  };
+
   return (
-    <Layout>
-      <DFASimulator />
+    <Layout automata={automata} setAutomata={setAutomata}>
+      {renderSim()}
     </Layout>
   );
 }

--- a/automata/frontend/src/components/CFG_components/CFGSimulator.jsx
+++ b/automata/frontend/src/components/CFG_components/CFGSimulator.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+// Simple CFG S -> a S b | epsilon
+function derive(target) {
+    const deriveRec = (current) => {
+        if (current === target) return true;
+        if (current.length > target.length) return false;
+        const idx = current.indexOf('S');
+        if (idx === -1) return false;
+        return deriveRec(current.replace('S', 'aSb')) || deriveRec(current.replace('S', ''));
+    };
+    return deriveRec('S');
+}
+
+const CFGSimulator = () => {
+    const [str, setStr] = useState('');
+    const [result, setResult] = useState(null);
+
+    const handleRun = () => {
+        setResult(derive(str) ? 'Generated' : 'Not generated');
+    };
+
+    return (
+        <div>
+            <h2>CFG Simulator</h2>
+            <input value={str} onChange={e => setStr(e.target.value)} />
+            <button onClick={handleRun}>Run</button>
+            {result && <div data-testid="cfg-result">{result}</div>}
+        </div>
+    );
+};
+
+export default CFGSimulator;

--- a/automata/frontend/src/components/Layout.jsx
+++ b/automata/frontend/src/components/Layout.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import './Layout.css';
 
-const Layout = ({ children }) => {
+const Layout = ({ children, automata, setAutomata }) => {
     return (
         <div className="layout">
             <header className="header">
@@ -19,9 +19,30 @@ const Layout = ({ children }) => {
                 <aside className="sidebar">
                     <div className="automata-types">
                         <h3>Automata Types</h3>
-                        <button className="type-btn active">DFA</button>
-                        <button className="type-btn disabled">NFA (Coming Soon)</button>
-                        <button className="type-btn disabled">PDA (Coming Soon)</button>
+                        <button
+                            className={`type-btn ${automata === 'DFA' ? 'active' : ''}`}
+                            onClick={() => setAutomata('DFA')}
+                        >
+                            DFA
+                        </button>
+                        <button
+                            className={`type-btn ${automata === 'PDA' ? 'active' : ''}`}
+                            onClick={() => setAutomata('PDA')}
+                        >
+                            PDA
+                        </button>
+                        <button
+                            className={`type-btn ${automata === 'TM' ? 'active' : ''}`}
+                            onClick={() => setAutomata('TM')}
+                        >
+                            TM
+                        </button>
+                        <button
+                            className={`type-btn ${automata === 'CFG' ? 'active' : ''}`}
+                            onClick={() => setAutomata('CFG')}
+                        >
+                            CFG
+                        </button>
                     </div>
 
                     <div className="toolbox">

--- a/automata/frontend/src/components/PDA_components/PDASimulator.jsx
+++ b/automata/frontend/src/components/PDA_components/PDASimulator.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+
+// Very small PDA that accepts strings of the form a^n b^n
+function runPDA(input) {
+    const stack = ['Z'];
+    for (let ch of input) {
+        if (ch === 'a') {
+            stack.push('A');
+        } else if (ch === 'b') {
+            if (stack.length <= 1) return false;
+            stack.pop();
+        } else {
+            return false;
+        }
+    }
+    return stack.length === 1;
+}
+
+const PDASimulator = () => {
+    const [str, setStr] = useState('');
+    const [result, setResult] = useState(null);
+
+    const handleRun = () => {
+        setResult(runPDA(str) ? 'Accepted' : 'Rejected');
+    };
+
+    return (
+        <div>
+            <h2>PDA Simulator</h2>
+            <input value={str} onChange={e => setStr(e.target.value)} />
+            <button onClick={handleRun}>Run</button>
+            {result && <div data-testid="pda-result">{result}</div>}
+        </div>
+    );
+};
+
+export default PDASimulator;

--- a/automata/frontend/src/components/TM_components/TMSimulator.jsx
+++ b/automata/frontend/src/components/TM_components/TMSimulator.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+
+// Simple TM that accepts binary strings with an even number of 0s
+const transitions = {
+    'q0,0': ['q1', '0', 'R'],
+    'q0,1': ['q0', '1', 'R'],
+    'q0,_': ['qa', '_', 'R'],
+    'q1,0': ['q0', '0', 'R'],
+    'q1,1': ['q1', '1', 'R'],
+    'q1,_': ['qr', '_', 'R'],
+};
+
+function runTM(input) {
+    let tape = input.split('');
+    let head = 0;
+    let state = 'q0';
+    const blank = '_';
+    while (true) {
+        const symbol = tape[head] === undefined ? blank : tape[head];
+        const key = `${state},${symbol}`;
+        const trans = transitions[key];
+        if (!trans) return state === 'qa';
+        const [next, write, move] = trans;
+        tape[head] = write;
+        head += move === 'R' ? 1 : -1;
+        state = next;
+        if (state === 'qa') return true;
+        if (state === 'qr') return false;
+    }
+}
+
+const TMSimulator = () => {
+    const [str, setStr] = useState('');
+    const [result, setResult] = useState(null);
+
+    const handleRun = () => {
+        setResult(runTM(str) ? 'Accepted' : 'Rejected');
+    };
+
+    return (
+        <div>
+            <h2>Turing Machine Simulator</h2>
+            <input value={str} onChange={e => setStr(e.target.value)} />
+            <button onClick={handleRun}>Run</button>
+            {result && <div data-testid="tm-result">{result}</div>}
+        </div>
+    );
+};
+
+export default TMSimulator;

--- a/automata/frontend/src/components/__tests__/Layout.test.jsx
+++ b/automata/frontend/src/components/__tests__/Layout.test.jsx
@@ -4,7 +4,7 @@ import Layout from '../Layout';
 
 describe('Layout', () => {
     test('renders header and navigation', () => {
-        render(<Layout />);
+        render(<Layout automata="DFA" setAutomata={() => {}} />);
 
         expect(screen.getByText('Interactive Automata Toolkit')).toBeInTheDocument();
         expect(screen.getByText('Documentation')).toBeInTheDocument();
@@ -12,16 +12,17 @@ describe('Layout', () => {
     });
 
     test('renders sidebar with automata types', () => {
-        render(<Layout />);
+        render(<Layout automata="DFA" setAutomata={() => {}} />);
 
         expect(screen.getByText('DFA')).toBeInTheDocument();
-        expect(screen.getByText('NFA (Coming Soon)')).toBeInTheDocument();
-        expect(screen.getByText('PDA (Coming Soon)')).toBeInTheDocument();
+        expect(screen.getByText('PDA')).toBeInTheDocument();
+        expect(screen.getByText('TM')).toBeInTheDocument();
+        expect(screen.getByText('CFG')).toBeInTheDocument();
     });
 
     test('renders children content', () => {
         render(
-            <Layout>
+            <Layout automata="DFA" setAutomata={() => {}}>
                 <div data-testid="test-content">Test Content</div>
             </Layout>
         );


### PR DESCRIPTION
## Summary
- allow Layout to switch between automaton types
- add small PDA, CFG and Turing Machine simulators
- update App component to render selected simulator
- adjust Layout tests for new buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'graphviz')*

------
https://chatgpt.com/codex/tasks/task_e_6880743498308333a8d64ba74c152251