### PR TITLE
Fix DFA creation and optional graphviz import

### DIFF
--- a/automata/backend/drawings/automata_drawer.py
+++ b/automata/backend/drawings/automata_drawer.py
@@ -1,8 +1,12 @@
 from typing import Dict, Set
-import graphviz
 from pathlib import Path
 import shutil
 import logging
+
+try:
+    import graphviz  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    graphviz = None
 
 logger = logging.getLogger(__name__)
 
@@ -18,8 +22,12 @@ class AutomataDrawer:
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Check if graphviz is installed
-        if not shutil.which("dot"):
+        # Warn if the graphviz package or executable is missing
+        if graphviz is None:
+            logger.warning(
+                "Python package 'graphviz' not found. Automata drawings will be disabled."
+            )
+        elif not shutil.which("dot"):
             logger.warning(
                 "Graphviz 'dot' command not found. Please install Graphviz:\n"
                 "  - MacOS: brew install graphviz\n"
@@ -84,6 +92,10 @@ class AutomataDrawer:
         Raises:
             RuntimeError: If Graphviz is not installed
         """
+        if graphviz is None:
+            raise RuntimeError(
+                "Python package 'graphviz' is required to draw automata."
+            )
         if not shutil.which("dot"):
             raise RuntimeError(
                 "Graphviz is not installed. Please install it first:\n"

--- a/automata/backend/grammar/regular_languages/dfa/dfa_mod_algo.py
+++ b/automata/backend/grammar/regular_languages/dfa/dfa_mod_algo.py
@@ -30,7 +30,12 @@ def create_dfa_from_table(
     """
     Build a DFA from a table of transitions.
     """
+    # Collect all states that appear either as a source or target
     all_states = set(table.keys())
+    for trans_dict in table.values():
+        all_states.update(trans_dict.values())
+    all_states.add(start_state)
+    all_states.update(accept_states)
     if alphabet is None:
         alpha_set = set()
         for trans_dict in table.values():


### PR DESCRIPTION
## Summary
- include all referenced states when constructing a DFA
- gracefully handle missing `graphviz` dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'graphviz')*

------
https://chatgpt.com/codex/tasks/task_e_68806d7f0d44833397aca1ae285fd03e