### PR TITLE
Add DFA JSON export in frontend

### DIFF
--- a/automata/frontend/src/components/DFA_components/DFASimulator.jsx
+++ b/automata/frontend/src/components/DFA_components/DFASimulator.jsx
@@ -174,6 +174,18 @@ const DFASimulator = () => {
         const handleClearAll = () => dfa.clearAll();
         const handleUndo = () => dfa.undo();
         const handleRedo = () => dfa.redo();
+        const handleExportJson = () => {
+            const json = dfa.exportToJSON();
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(json).then(() => {
+                    alert('DFA JSON copied to clipboard');
+                }, () => {
+                    alert(json);
+                });
+            } else {
+                alert(json);
+            }
+        };
 
         window.addEventListener('addState', handleAddState);
         window.addEventListener('addSymbol', handleAddSymbol);
@@ -182,6 +194,7 @@ const DFASimulator = () => {
         window.addEventListener('clearAll', handleClearAll);
         window.addEventListener('undo', handleUndo);
         window.addEventListener('redo', handleRedo);
+        window.addEventListener('exportJson', handleExportJson);
 
         return () => {
             window.removeEventListener('addState', handleAddState);
@@ -191,6 +204,7 @@ const DFASimulator = () => {
             window.removeEventListener('clearAll', handleClearAll);
             window.removeEventListener('undo', handleUndo);
             window.removeEventListener('redo', handleRedo);
+            window.removeEventListener('exportJson', handleExportJson);
         };
     }, [dfa]);
 

--- a/automata/frontend/src/components/DFA_components/useDFA.js
+++ b/automata/frontend/src/components/DFA_components/useDFA.js
@@ -240,6 +240,16 @@ export const useDFA = (initialDFA) => {
         });
     }, [states, alphabet, transitions, startState, acceptStates, saveToHistory]);
 
+    const exportToJSON = useCallback(() => {
+        return JSON.stringify({
+            states,
+            alphabet,
+            transitions,
+            startState,
+            acceptStates: Array.from(acceptStates)
+        }, null, 2);
+    }, [states, alphabet, transitions, startState, acceptStates]);
+
     return {
         states,
         alphabet,
@@ -261,6 +271,7 @@ export const useDFA = (initialDFA) => {
         hasTransition,
         removeTransition,
         deleteState,
-        deleteSymbol
+        deleteSymbol,
+        exportToJSON
     };
-}; 
+};

--- a/automata/frontend/src/components/Layout.jsx
+++ b/automata/frontend/src/components/Layout.jsx
@@ -42,6 +42,9 @@ const Layout = ({ children }) => {
                             <button onClick={() => window.dispatchEvent(new CustomEvent('clearAll'))}>
                                 Clear All
                             </button>
+                            <button onClick={() => window.dispatchEvent(new CustomEvent('exportJson'))}>
+                                Export JSON
+                            </button>
                         </div>
                     </div>
 

--- a/automata/frontend/src/components/__tests__/DFASimulator.test.jsx
+++ b/automata/frontend/src/components/__tests__/DFASimulator.test.jsx
@@ -47,4 +47,13 @@ describe('DFASimulator', () => {
         // Check result
         expect(screen.getByText('String accepted')).toBeInTheDocument();
     });
-}); 
+
+    test('exports DFA json', () => {
+        render(<DFASimulator />);
+        const exportButton = screen.getByText('Export JSON');
+        const writeText = jest.fn(() => Promise.resolve());
+        Object.assign(navigator, { clipboard: { writeText } });
+        fireEvent.click(exportButton);
+        expect(writeText).toHaveBeenCalled();
+    });
+});

--- a/automata/frontend/src/components/__tests__/Layout.test.jsx
+++ b/automata/frontend/src/components/__tests__/Layout.test.jsx
@@ -28,4 +28,9 @@ describe('Layout', () => {
 
         expect(screen.getByTestId('test-content')).toBeInTheDocument();
     });
-}); 
+
+    test('includes export json button', () => {
+        render(<Layout />);
+        expect(screen.getByText('Export JSON')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary
- enable exporting DFA config as JSON in the React frontend
- hook export button in Layout
- expose export function in DFA hook
- update tests for new functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `graphviz`)*

------
https://chatgpt.com/codex/tasks/task_e_688071cf66b08333ad2e338abd69e721